### PR TITLE
fix(ci): skip PR creation when SDK generation produces no changes

### DIFF
--- a/.github/workflows/generate-sdks.yml
+++ b/.github/workflows/generate-sdks.yml
@@ -21,7 +21,18 @@ jobs:
       - name: Generate SDKs
         working-directory: protos
         run: buf generate
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No SDK changes detected"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "SDK changes detected"
+          fi
       - name: Create Pull Request
+        if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           # Use PAT if provided, otherwise fallback to the built-in GitHub token


### PR DESCRIPTION
This pull request adds a safeguard to the SDK generation workflow to ensure that a pull request is only created if there are actual changes to the generated SDKs. This helps prevent unnecessary pull requests when no updates have occurred.

Workflow improvements:

* Added a new step to check for changes after SDK generation by running `git diff --quiet` and setting an output flag (`has_changes`) accordingly.
* Updated the "Create Pull Request" step to run only if changes are detected, using the output from the previous step as a condition.